### PR TITLE
Add symfony 3.0 support and use safer constraints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,29 @@ php:
     - 5.3
     - 5.4
     - 5.5
+    - 5.6
+
+cache:
+  directories:
+    - $HOME/.composer/cache/files
 
 matrix:
-    allow_failures:
-        - php: 5.5
+  fast_finish: true
+  include:
+    - php: 5.5
+      env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak
+    - php: 5.6
+      env: SYMFONY_VERSION='2.7.*'
+    - php: 5.6
+      env: SYMFONY_VERSION='2.8.*'
 
-before_script:
+before_install:
+    - composer self-update
+    - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony=$SYMFONY_VERSION; fi
     - git clone git://github.com/nicolasff/phpredis.git
     - cd phpredis && phpize && ./configure && make && sudo make install && cd ..
     - echo "extension=redis.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
-    - composer install --dev
+
+install: composer update $COMPOSER_FLAGS
 
 script: phpunit

--- a/DependencyInjection/RSQueueExtension.php
+++ b/DependencyInjection/RSQueueExtension.php
@@ -3,6 +3,7 @@
 namespace Mmoreram\RSQueueBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
@@ -39,5 +40,23 @@ class RSQueueExtension extends Extension
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
+
+        // BC sf < 2.6
+        $definition = $container->getDefinition('rs_queue.serializer');
+        if (method_exists($definition, 'setFactory')) {
+            $definition->setFactory(array(new Reference('rs_queue.serializer.factory'), 'get'));
+        } else {
+            $definition->setFactoryService('rs_queue.serializer.factory');
+            $definition->setFactoryMethod('get');
+        }
+
+        // BC sf < 2.6
+        $definition = $container->getDefinition('rs_queue.redis');
+        if (method_exists($definition, 'setFactory')) {
+            $definition->setFactory(array(new Reference('rs_queue.redis.factory'), 'get'));
+        } else {
+            $definition->setFactoryService('rs_queue.redis.factory');
+            $definition->setFactoryMethod('get');
+        }
     }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,8 +1,8 @@
 parameters:
-    rs_queue.serializer.factory.class: "Mmoreram\RSQueueBundle\Factory\SerializerFactory"
-    rs_queue.serializer.interface: "Mmoreram\RSQueueBundle\SerializerInterface"
-    rs_queue.redis.factory.class: "Mmoreram\RSQueueBundle\Factory\RedisFactory"
-    rs_queue.resolver.queuealias.class: "Mmoreram\RSQueueBundle\Resolver\QueueAliasResolver"
+    rs_queue.serializer.factory.class: Mmoreram\RSQueueBundle\Factory\SerializerFactory
+    rs_queue.serializer.interface: Mmoreram\RSQueueBundle\SerializerInterface
+    rs_queue.redis.factory.class: Mmoreram\RSQueueBundle\Factory\RedisFactory
+    rs_queue.resolver.queuealias.class: Mmoreram\RSQueueBundle\Resolver\QueueAliasResolver
 
 services:
 
@@ -13,8 +13,6 @@ services:
 
     rs_queue.serializer:
         class: %rs_queue.serializer.interface%
-        factory_service: rs_queue.serializer.factory
-        factory_method: get
 
     rs_queue.redis.factory:
         class: %rs_queue.redis.factory.class%
@@ -23,8 +21,6 @@ services:
 
     rs_queue.redis:
         class: Redis
-        factory_service: rs_queue.redis.factory
-        factory_method: get
 
     rs_queue.resolver.queuealias:
         class: %rs_queue.resolver.queuealias.class%
@@ -34,10 +30,10 @@ services:
     rs_queue.service:
         abstract: true
         arguments:
-            eventDispatcher: @event_dispatcher
-            redis: @rs_queue.redis
-            queueNamesResolver: @rs_queue.resolver.queuealias
-            serializer: @rs_queue.serializer
+            eventDispatcher: "@event_dispatcher"
+            redis: "@rs_queue.redis"
+            queueNamesResolver: "@rs_queue.resolver.queuealias"
+            serializer: "@rs_queue.serializer"
 
     rs_queue.consumer:
         class: Mmoreram\RSQueueBundle\Services\Consumer

--- a/Tests/DependencyInjection/RSQueueExtensionTest.php
+++ b/Tests/DependencyInjection/RSQueueExtensionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the FOSRestBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mmoreram\RSQueueBundle\Tests\DependencyInjection;
+
+use Mmoreram\RSQueueBundle\DependencyInjection\RSQueueExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\DefinitionDecorator;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * RSQueueExtension test.
+ *
+ * @author Ener-Getick <egetick@gmail.com>
+ */
+class RSQueueExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ContainerBuilder
+     */
+    private $container;
+
+    /**
+     * @var RSQueueExtension
+     */
+    private $extension;
+
+    public function setUp()
+    {
+        $this->container = new ContainerBuilder();
+        $this->extension = new RSQueueExtension();
+    }
+
+    public function testExtension() {
+        $config = array();
+        $this->extension->load($config, $this->container);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -13,22 +13,20 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/event-dispatcher": ">=2.1",
-        "symfony/framework-bundle": ">=2.1",
-        "doctrine/annotations": ">=1.1.2",
-        "symfony/console": ">=2.1",
-        "symfony/config": ">=2.1",
-        "symfony/http-kernel": ">=2.1",
-        "symfony/dependency-injection": ">=2.1"
+        "symfony/event-dispatcher": "~2.3|~3.0",
+        "symfony/framework-bundle": "~2.3|~3.0",
+        "doctrine/annotations": "^1.1.2",
+        "symfony/console": "~2.3|~3.0",
+        "symfony/config": "~2.3|~3.0",
+        "symfony/http-kernel": "~2.3|~3.0",
+        "symfony/dependency-injection": "~2.3|~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "symfony/phpunit-bridge": "~2.7"
     },
-    "target-dir": "Mmoreram/RSQueueBundle",
     "autoload": {
-        "psr-0": { "Mmoreram\\RSQueueBundle": "" }
+        "psr-4": { "Mmoreram\\RSQueueBundle\\": "" }
     },
-    "minimum-stability": "stable",
     "extra": {
         "branch-alias": {
             "dev-master": "1.0-dev"


### PR DESCRIPTION
This PR fixes a deprecation and use safer constraints