### PR TITLE
Return an empty array when the payload is empty

### DIFF
--- a/Services/Consumer.php
+++ b/Services/Consumer.php
@@ -43,6 +43,10 @@ class Consumer extends AbstractService
 
         $payloadArray = $this->redis->blpop($queues, $timeout);
 
+        if (empty($payloadArray)) {
+            return array();
+        }
+
         list($givenQueue, $payloadSerialized) = $payloadArray;
         $payload = $this->serializer->revert($payloadSerialized);
         $givenQueueAlias = $this->queueAliasResolver->getQueueAlias($givenQueue);


### PR DESCRIPTION
this occurs when blpop times out, otherwise an exception is thrown when the consumer times out (without any payload data)