### PR TITLE
Remove the note on server conf in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,7 @@ return array(
 
 ## Configuration
 
-In this first version, all conections are localhost:6379, but as soon as posible connections will be configurable.  
-You need to configure all queues and serializer.  
+In order to produce and consume messages, you need to configure all the queues and the serializer.  
 By default serializer has the value 'Json', but also 'PHP' value can be used. Also custom serializer can be implemented by extending default serializer interface. Then you need to add namespace of class into the rs_queue.serializer parameter.
 
 ``` yml


### PR DESCRIPTION
Looks like the note about all connections being made to `localhost:6379` is not relevant anymore.